### PR TITLE
Remove space that breaks ${PIDFILE} var expansion

### DIFF
--- a/markdown/reference/sauce-connect.md
+++ b/markdown/reference/sauce-connect.md
@@ -291,7 +291,7 @@ post-start script
   max_tries=30
   while [ $n -le $max_tries ]; do
     if [ -f $PIDFILE ]; then
-      cp $PIDFILE $ {PIDFILE}.saved
+      cp $PIDFILE ${PIDFILE}.saved
       break
     fi
     n=$((n+1))


### PR DESCRIPTION
This change fixes an issue where the upstart config file shows the following error when "start sc" is run:

cp: target `{PIDFILE}.saved' is not a directory