### PR TITLE
Clarify the problems with IEDriver Bittedness

### DIFF
--- a/markdown/reference/test-configuration.md
+++ b/markdown/reference/test-configuration.md
@@ -468,7 +468,7 @@ Value Type: string
 Example:
 
 ```python
-"iedriverVersion": "2.42.0"
+"iedriverVersion": "2.45.0"
 ```
 
 The list of supported IE Drivers you can choose from:<br/>

--- a/markdown/reference/test-configuration.md
+++ b/markdown/reference/test-configuration.md
@@ -455,7 +455,7 @@ Example:
 
 The specific version of the IE Driver executable can be customized using the `iedriverVersion` key.
 
-In particular, Sauce supports launching 64-bit IE on our 64-bit VMs: Windows 7, Windows 8, and Windows 8.1.  This provides a workaround for two known Selenium issues:
+In particular, Sauce Labs supports launching 64-bit IE on our 64-bit VMs: Windows 7, Windows 8, and Windows 8.1.  This provides a workaround for two known Selenium issues:
 
 Using a 32 bit driver on a 64 bit operating system causes Selenium's screenshot feature to only capture the part of the page currently visible in the browser viewport [Selenium Issue 5876](https://code.google.com/p/selenium/issues/detail?id=5876).
 

--- a/markdown/reference/test-configuration.md
+++ b/markdown/reference/test-configuration.md
@@ -473,7 +473,7 @@ Example:
 
 The list of supported IE Drivers you can choose from:<br/>
 
-`2.21.1`, `2.21.2`, `2.24.0`, `2.25.3`, `2.26.0`, `2.28.0`, `2.29.0`, `2.30.1`, `2.31.0`, `2.32.2`, `2.33.0`, `2.34.0`, `2.35.0`, `2.35.1`, `2.35.2`, `2.35.3`, `2.36.0`, `2.37.0`, `2.38.0`, `2.39.0`, `2.40.0`, `2.41.0`, `2.42.0`, `x64_2.29.0`, `x64_2.39.0`, `x64_2.40.0`, `x64_2.41.0`, `x64_2.42.0`
+`2.21.1`, `2.21.2`, `2.24.0`, `2.25.3`, `2.26.0`, `2.28.0`, `2.29.0`, `2.30.1`, `2.31.0`, `2.32.2`, `2.33.0`, `2.34.0`, `2.35.0`, `2.35.1`, `2.35.2`, `2.35.3`, `2.36.0`, `2.37.0`, `2.38.0`, `2.39.0`, `2.40.0`, `2.41.0`, `2.42.0`, `2.43.0`, `2.44.0`, `2.45.0`, `x64_2.29.0`, `x64_2.39.0`, `x64_2.40.0`, `x64_2.41.0`, `x64_2.42.0`, `x64_2.43.0`, `x64_2.44.0`, `x64_2.45.0`
 
 ### Pop-up Handling
 Sauce provides a pop-up handler that automatically clicks through some types of browser pop-up windows, to allow tests to continue. By default, this feature is turned on for Selenium RC and off for WebDriver tests. You can control the pop-up handler yourself with the following capability:

--- a/markdown/reference/test-configuration.md
+++ b/markdown/reference/test-configuration.md
@@ -455,7 +455,11 @@ Example:
 
 The specific version of the IE Driver executable can be customized using the `iedriverVersion` key.
 
-In particular, Sauce supports launching 64-bit IE on our 64-bit VMs: Windows 7, Windows 8, and Windows 8.1. This provides a workaround for a known Selenium bug causing screencaptures using the 32-bit driver on a 64-bit operating system to fail to capture the whole web page.
+In particular, Sauce supports launching 64-bit IE on our 64-bit VMs: Windows 7, Windows 8, and Windows 8.1.  This provides a workaround for two known Selenium issues:
+
+Using a 32 bit driver on a 64 bit operating system causes Selenium's screenshot feature to only capture the part of the page currently visible in the browser viewport [Selenium Issue 5876](https://code.google.com/p/selenium/issues/detail?id=5876).
+
+Using a 64 bit driver on a 64 bit operating system causes text entry to be extremely slow [Selenium Issue 5516](https://code.google.com/p/selenium/issues/detail?id=5116).
 
 Key: `iedriverVersion`
 
@@ -464,7 +468,7 @@ Value Type: string
 Example:
 
 ```python
-"iedriverVersion": "x64_2.41.0"
+"iedriverVersion": "2.42.0"
 ```
 
 The list of supported IE Drivers you can choose from:<br/>

--- a/markdown/tutorials/appium.md
+++ b/markdown/tutorials/appium.md
@@ -81,10 +81,10 @@ Your first test will run against our Test Application, which is hosted on Sauce.
 
 To run your first test, simply run the quick start code below. Our example is in Ruby using RSpec, though Appium can be used with almost any language and test framework:
 
-To run the Ruby example, you need to have rspec installed, in addition to the Selenium WebDriver client library. To install these, and download a simple example test, run:
+To run the Ruby example, you need to have Ruby and Bundler installed.  Then, you can get Bundler to install the required gems, and download the sample test, by running:
 
 ```bash
-curl -L https://raw.github.com/saucelabs/appium-tutorial/master/bin/install_tutorial_ruby.sh | bash -s
+curl -L https://raw.githubusercontent.com/saucelabs/appium-tutorial/master/bin/install_tutorial_ruby.sh | bash -s
 ```
 
 Now you are ready to run your first test! The `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` environment variables authenticate you with Sauce Labs:


### PR DESCRIPTION
If you use the 32 bit version of IEDriver, then attempt to take a screenshot using Selenium, you get a screenshot sized the same size as the entire page, but only the part visible in the viewport is shown; the rest is black.  But, your text entry goes full speed.

If you use the 64 bit version of IEDriver, then attempt to take a screenshot using Selenium, you get a screenshot sized the same size as the entire page, and the entire thing is present.  But, your text entry speed is tectonically slow.

They also don't have a timeline on a fix.

These changes make the latest 32 bit version the version we show as an example (Slow keys is FAR worse then incomplete screenshots IMO;  You only see part of the page at any one time anyway).  It also adds the latest couple of releases to the list of available releases.