### PR TITLE
Update Ruby tutorial to 3.5.6

### DIFF
--- a/markdown/tutorials/ruby.md
+++ b/markdown/tutorials/ruby.md
@@ -8,7 +8,7 @@
 
 The [sauce gem](https://github.com/saucelabs/sauce_ruby) makes it easy to run Selenium or Capybara tests against a wide range of browsers on Windows (XP, 7, 8), OS X, Linux, iOS and Android.
 
-This example uses [Capybara](http://jnicklas.github.com/capybara/) and RSpec with Rails 3 and Ruby 1.9, but Sauce Labs also works great against any Ruby web stack, and with [Test::Unit](https://saucelabs.com/docs/ondemand/getting-started/env/ruby/se2/mac), [Cucumber](https://github.com/sauce-labs/sauce_ruby/wiki/Cucumber-and-Capybara), and most other testing frameworks... right down to vanilla [WebDriver](http://code.google.com/p/selenium/wiki/RubyBindings).
+This example uses [Capybara](http://jnicklas.github.com/capybara/) and RSpec with Rails 4 and Ruby 2.0, but Sauce Labs also works great against any Ruby web stack, and with [Test::Unit](https://saucelabs.com/docs/ondemand/getting-started/env/ruby/se2/mac), [Cucumber](https://github.com/sauce-labs/sauce_ruby/wiki/Cucumber-and-Capybara), and most other testing frameworks... right down to vanilla [WebDriver](http://code.google.com/p/selenium/wiki/RubyBindings).
 
 Your tests are run in real browsers on a real operating system, in a
 dedicated, single-use VM.  Once they're complete, screenshots, video,
@@ -17,24 +17,30 @@ Selenium log and a log of passes and failures can be seen and shared.
 
 What You'll Need
 ----------------
+A working Ruby 2.0 environment with Bundler & the Rails gem installed.
+
+Sauce Connect downloaded from [here](https://docs.saucelabs.com/reference/sauce-connect/), unzipped in a known location.  Take note of the path to the `sc` executable, inside the `bin` subdirectory; You'll need it later.
+
+A bash terminal open in your Rails app's root directory.
 
 In your Gemfile:
 
 ```ruby
-group :test, :development do
-  # These are the target gems of this tutorial
-  gem 'rspec-rails', '~> 2.12'
-  gem 'sauce', '~> 3.1.1'
+group :development, :test do
+  # These are the target gems of this tutorial but Sauce Labs works for almost
+  # every WebDriver enabled testing tool
+  gem 'rspec-rails', '~> 3.2.1'
+  gem 'sauce', '~> 3.5.6'
   gem 'sauce-connect'
-  gem 'capybara', '~> 2.0.3'
+  gem 'capybara', '~> 2.4.4'
   gem 'parallel_tests'
 end
 ```
 
 Setting up RSpec
------------
+----------------
 
-From your `RAILS_ROOT`, generate a ./spec directory, a ./spec/spec_helper.rb file, and a warm, fuzzy feeling of productivity by executing:
+From your `RAILS_ROOT`, `bundle install`, then generate a ./spec directory, a ./spec/spec_helper.rb file, and a warm, fuzzy feeling of productivity by executing:
 
 ```bash
 rails generate rspec:install
@@ -46,13 +52,11 @@ Set up your `spec_helper` and create a template `sauce_helper`, by running:
 rake sauce:install:spec
 ```
 
-Now, open the new spec/sauce_helper.rb file, and just under the `require` statements, add requires for `capybara/rails` and `capybara/rspec`. Finally, set the default Capybara driver to be Sauce:
+Now, open the new spec/sauce_helper.rb file, and just under the `require` statements, add requires for `capybara/rails` and `capybara/rspec`.
 
-```ruby
-Capybara.default_driver = :sauce
-```
+Once this is done, edit the Sauce.config block to configure your desired test platforms by adding entries to the `browsers` array ([details here](https://github.com/saucelabs/sauce_ruby#converting-sauce-labs-capabilities)).
 
-Once this is done, you can configure your desired test platforms. Here's an example:
+You'll also need to tell the Sauce Connect gem where to find the copy of Sauce Connect you downloaded and unzipped earlier; set the `:sauce_connect_4_executable` key to the path you took note of earlier (including the `bin/sc` part!)
 
 ```ruby
 # Use Capybara integration
@@ -61,17 +65,19 @@ require "sauce/capybara"
 require "capybara/rails"
 require "capybara/rspec"
 
-Capybara.default_driver = :sauce
-
 # Set up configuration
 Sauce.config do |c|
-  c[:browsers] = [
+  config[:browsers] = [
     ["Windows 8", "Internet Explorer", "10"],
     ["Windows 7", "Firefox", "20"],
-    ["OS X 10.8", "Safari", "6"],
-    ["Linux", "Chrome", nil]
+    ["OS X 10.10", "Safari", "8"],
+    ["Linux", "Chrome", 40]
   ]
+  config[:sauce_connect_4_executable] = '/some/file/path/sc-4.3.8-osx/bin/sc'
 end
+
+Capybara.default_driver = :sauce
+Capybara.javascript_driver = :sauce
 ```
 
 Check out [our platforms page](http://saucelabs.com/docs/platforms) for available platforms (400+ and counting!).
@@ -113,14 +119,16 @@ Turn on the Sauce voodoo by tagging each describe block ('example group' in RSpe
     $ vim ./spec/features/ramen_spec.rb
 
 ```ruby
-require "spec_helper"
+require "rails_helper"
 
 describe "Wikipedia's Ramen Page", :sauce => true do
   it "Should mention the inventor of instant Ramen" do
     visit "http://en.wikipedia.org/"
     fill_in 'search', :with => "Ramen"
     click_button "searchButton"
-    page.should have_content "Momofuku Ando"
+
+    heading = find '#firstHeading'
+    expect( heading ).to have_content "Ramen"
   end
 end
 ```
@@ -129,14 +137,16 @@ That's one spec, how about another?
     $ vim ./spec/features/miso_spec.rb
 
 ```ruby
-require "spec_helper"
+require "rails_helper"
 
 describe "Wikipedia's Miso Page", :sauce => true do
   it "Should mention a favorite type of Miso" do
     visit "http://en.wikipedia.org/"
     fill_in 'search', :with => "Miso"
     click_button "searchButton"
-    page.should have_content "Akamiso"
+    
+    heading = find '#firstHeading'
+    expect( heading ).to have_content "Miso"
   end
 end
 ```
@@ -152,7 +162,9 @@ rake sauce:spec
 
 It's that simple (Thanks in part to the excellent [parallel_tests](https://github.com/grosser/parallel_tests) gem.)
 Your tests will run once for every platform, taking advantage of Sauce Labs to run at the maximum concurrency for your
-account. The sauce:spec rake command takes two optional parameters to let you control the directory you keep your specs
+account.
+
+The sauce:spec rake command takes two optional parameters to let you control the directory you keep your specs
 in and the level of concurrency at which you run them. For example, to run specs from the "spec" directory one at a time,
 you'd run the command like so: 
 
@@ -164,17 +176,16 @@ You should see output much like the following:
 
 ```
 20 processes for 8 specs, ~ 0 specs per process
-[Connecting to Sauce Labs...]
-Sauce Connect 3.0-r25, build 38
+[Sauce Connect is connecting to Sauce Labs...]
 
 [snip]A LOT OF TEST DATA[/snip]
 
-8 examples, 0 failures
+8 examples, 2 failures
 
-Took 196.657036 seconds
+Took 257 seconds (4:17)
 ```
 
-The `8 examples, 0 failures` line means your tests are running against each browser, and passing. Congratulations!
+The `6 examples, 2 failures` line means your tests are running against each browser, passing 6 times (two tests passing in three browsers each) and failing twice (That's in OS X, and is expected for this example). Congratulations!
 
 Running in parallel makes your build faster, so you can run more tests in more browsers in less total time.
 


### PR DESCRIPTION
Update versions of gems references.
Include section referencing SC4 executable.
Update sample tests to reflect current practice for RSpec.
Make it clearer what expectations we have of customers.
