### PR TITLE
SUP-130 add sc proxy ports back

### DIFF
--- a/markdown/reference/sauce-connect.md
+++ b/markdown/reference/sauce-connect.md
@@ -374,13 +374,13 @@ When using Sauce Connect, local web apps running on commonly-used ports are avai
 
 However, because an additional proxy is required for localhost URLs, tests may perform better when using a locally-defined domain name (which can be set in your [hosts file](http://en.wikipedia.org/wiki/Hosts_\(file\))) rather than localhost. Using a locally-defined domain name also allows access to applications on any port.
 
-Sauce Connect proxies these commonly-used localhost ports:
-
 **Please Note**: On Android devices ports 5555 and 8080 cannot be used with Sauce Connect.
+
+**The Safari browser** on OS X 10.10 Yosemite and mobile iOS 8+ proxies the following common ports:
 
 > 80, 443, 888, 2000, 2001, 2020, 2109, 2222, 2310, 3000, 3001, 3030, 3210, 3333, 4000, 4001, 4040, 4321, 4502, 4503, 4567, 5000, 5001, 5050, 5555, 5432, 6000, 6001, 6060, 6666, 6543, 7000, 7070, 7774, 7777, 8000, 8001, 8003, 8031, 8080, 8081, 8765, 8777, 8888, 9000, 9001, 9080, 9090, 9876, 9877, 9999, 49221, 55001
 
-Most browsers will accept ports beyond this list, but if you're seeing issues and need a new port added, [please let us know!](http://support.saucelabs.com/anonymous_requests/new) We do our best to support ports that will be useful for many customers, such as those used by popular frameworks.
+If you're testing on Safari and need a different port, [please let us know!](http://support.saucelabs.com/anonymous_requests/new) We do our best to support ports that will be useful for many customers, such as those used by popular frameworks.
 
 
 ### How can I improve performance?

--- a/markdown/reference/sauce-connect.md
+++ b/markdown/reference/sauce-connect.md
@@ -374,7 +374,14 @@ When using Sauce Connect, local web apps running on commonly-used ports are avai
 
 However, because an additional proxy is required for localhost URLs, tests may perform better when using a locally-defined domain name (which can be set in your [hosts file](http://en.wikipedia.org/wiki/Hosts_\(file\))) rather than localhost. Using a locally-defined domain name also allows access to applications on any port.
 
+Sauce Connect proxies these commonly-used localhost ports:
+
 **Please Note**: On Android devices ports 5555 and 8080 cannot be used with Sauce Connect.
+
+> 80, 443, 888, 2000, 2001, 2020, 2109, 2222, 2310, 3000, 3001, 3030, 3210, 3333, 4000, 4001, 4040, 4321, 4502, 4503, 4567, 5000, 5001, 5050, 5555, 5432, 6000, 6001, 6060, 6666, 6543, 7000, 7070, 7774, 7777, 8000, 8001, 8003, 8031, 8080, 8081, 8765, 8777, 8888, 9000, 9001, 9080, 9090, 9876, 9877, 9999, 49221, 55001
+
+Most browsers will accept ports beyond this list, but if you're seeing issues and need a new port added, [please let us know!](http://support.saucelabs.com/anonymous_requests/new) We do our best to support ports that will be useful for many customers, such as those used by popular frameworks.
+
 
 ### How can I improve performance?
 


### PR DESCRIPTION
Subject: Add list of SC proxy ports back to SC docs | SUP-130
 
Description
===========
 
**Ticket**: [SUP-130](https://saucedev.atlassian.net/browse/SUP-130)
@colinsauce it seems we need to add these back - mind taking a look? Thanks!

#### Problem

We removed the SC proxy ports thinking they were no longer relevant. Turns out Safari still cares.

#### Solution

Adding the ports back.

#### Comments

--

#### Possible improvements

--

#### Checklist

- [ ] Is there any cruft that should be removed along with this code change? [comment if yes]
- [ ] Is that code change resulting in any SQL query changes to the database? [comment if yes]
- [ ] Have you inspected queries that are run on the DB by the changed code? [comment if yes]
- [ ] Is that code change resulting in any performance changes to the application)? [comment if yes]