### PR TITLE
Removing the last Selenium RC reference I see | SUP-133

### DIFF
--- a/markdown/reference/rest-api.md
+++ b/markdown/reference/rest-api.md
@@ -453,7 +453,6 @@ Get a list of objects describing all the OS and browser platforms currently supp
 * `all`
 * `appium`
 * `webdriver`
-* `selenium-rc`
 
 **Example Request:**
 ```bash


### PR DESCRIPTION
**Ticket**: [SUP-133](https://saucedev.atlassian.net/browse/SUP-133)

@saucyallison please review

#### Problem

Selenium RC is dead

#### Solution

remove it so customers don't try to go down that scary road

#### Comments

#### Possible improvements

#### Checklist

- [ ] Is there any cruft that should be removed along with this code change? [comment if yes]
- [ ] Is that code change resulting in any SQL query changes to the database? [comment if yes]
- [ ] Have you inspected queries that are run on the DB by the changed code? [comment if yes]
- [ ] Is that code change resulting in any performance changes to the application)? [comment if yes]